### PR TITLE
Fix duplicate listeners in toast hook

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -179,7 +179,11 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+    // Adding the listener should only happen once when the
+    // component using this hook mounts. Using an empty
+    // dependency array prevents duplicating listeners whenever
+    // the toast state updates.
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- update `useToast` effect so listeners are only registered on mount

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_684d880c94588329a311f735a90d5ddf