### PR TITLE
Fix GitHub Pages blank page

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,6 @@
 
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  base: '/tech-route-resume-guide/',
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- set Vite `base` option for GitHub Pages
- use relative path to main script in `index.html`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_684d8890cb108329bbf39f39d283ea64